### PR TITLE
Exclude all hidden dirs started with '.'

### DIFF
--- a/Admin_TinyPNG.php
+++ b/Admin_TinyPNG.php
@@ -332,7 +332,7 @@ class Admin_TinyPNG {
 
 		foreach($files as $file){
 
-			if( $file == '.' || $file == '..' || $file == $temp ){
+			if( $file[0] == '.' || $file == $temp ){
 				continue;
 			}
 


### PR DESCRIPTION
To exclude .tmb directories created by CKE4, which is used in TS 5.2